### PR TITLE
remove callback from emit

### DIFF
--- a/src/client/method.js
+++ b/src/client/method.js
@@ -587,7 +587,7 @@ const dispatch = (state, done) => {
 // ############ interface ############
 
 const bind = (div, item) => {}
-const emit = (div, item, done) => {
+const emit = async (div, item) => {
   let input = {}
   let output = {}
 
@@ -680,9 +680,11 @@ const emit = (div, item, done) => {
   })
 
   let state = { div, item, input, output, report: [] }
-  dispatch(state, state => {
-    refresh(state)
-    setTimeout(done, 10) // slower is better for firefox
+  await new Promise(resolve => {
+    dispatch(state, state => {
+      refresh(state)
+      setTimeout(resolve, 10) // slower is better for firefox
+    })
   })
 }
 


### PR DESCRIPTION
Here we remove the callback from the emit preferring to make it async instead.

This work precipitated by the deprecation of callbacks when we emit from plugins.
https://github.com/fedwiki/wiki-client/pull/348

Method evaluates the calculation called for by its markup during the emit. This evaluation expects a callback itself. This is where display update happens such that computations show in the freshly emitted display. We wrap this logic with `new Promise(...)` replacing the sole reference to the removed emit parameter with the `resolve` offered by the promise.